### PR TITLE
Create a payload for an APS hook to start APS Workflows

### DIFF
--- a/repository/src/main/config/bootstrap/action-templates.xml
+++ b/repository/src/main/config/bootstrap/action-templates.xml
@@ -28,6 +28,13 @@
                                     <cm:content>contentUrl=classpath:alfresco/module/${moduleId}/bootstrap/content/mattermost_new_file.json.ftl|mimetype=text/plain|size=|encoding=UTF-8</cm:content>
                                 </view:properties>
                             </cm:content>
+                            <cm:content view:childName="cm:aps_new_file.json.ftl">
+                                <view:properties>
+                                    <cm:name>aps_new_file.json.ftl</cm:name>
+                                    <cm:title>\${${moduleId}.content.templates.apsNewFilePayloadTemplate.title}</cm:title>
+                                    <cm:content>contentUrl=classpath:alfresco/module/${moduleId}/bootstrap/content/aps_new_file.json.ftl|mimetype=text/plain|size=|encoding=UTF-8</cm:content>
+                                </view:properties>
+                            </cm:content>
                         </cm:contains>
                     </view:associations>
                 </cm:folder>

--- a/repository/src/main/config/bootstrap/content/aps_new_file.json.ftl
+++ b/repository/src/main/config/bootstrap/content/aps_new_file.json.ftl
@@ -1,0 +1,12 @@
+<#escape x as jsonUtils.encodeJSONString(x)>{
+    "signalName":"mysignal",
+    "tenantId":"tenant_1",
+    "async":"false",
+    "variables":
+    [
+        {
+            "name":"document",
+            "value":"${document.nodeRef}"
+        }
+    ]
+}</#escape>

--- a/repository/src/main/config/bootstrap/content/aps_new_file.json.ftl
+++ b/repository/src/main/config/bootstrap/content/aps_new_file.json.ftl
@@ -1,7 +1,7 @@
 <#escape x as jsonUtils.encodeJSONString(x)>{
-    "signalName":"mysignal",
-    "tenantId":"tenant_1",
-    "async":"false",
+    "signalName":"${signalName!"mysignal"}",
+    "tenantId":"${tenantId!"tenant_1"}",
+    "async":"${async!"false"}",
     "variables":
     [
         {

--- a/repository/src/main/messages/bootstrap.properties
+++ b/repository/src/main/messages/bootstrap.properties
@@ -2,4 +2,4 @@ ${moduleId}.spaces.templates.actionTemplates.name=Acosix Action Templates
 ${moduleId}.spaces.templates.webhookPayloadTemplates.name=Webhook Call Payload Templates
 ${moduleId}.content.templates.discordNewFilePayloadTemplate.title="New File" Discord Payload
 ${moduleId}.content.templates.mattermostNewFilePayloadTemplate.title="New File" Mattermost Payload
-${moduleId}.content.templates.apsNewFilePayloadTemplate.title="New File" Aps Payload
+${moduleId}.content.templates.apsNewFilePayloadTemplate.title="New File" APS Payload

--- a/repository/src/main/messages/bootstrap.properties
+++ b/repository/src/main/messages/bootstrap.properties
@@ -2,3 +2,4 @@ ${moduleId}.spaces.templates.actionTemplates.name=Acosix Action Templates
 ${moduleId}.spaces.templates.webhookPayloadTemplates.name=Webhook Call Payload Templates
 ${moduleId}.content.templates.discordNewFilePayloadTemplate.title="New File" Discord Payload
 ${moduleId}.content.templates.mattermostNewFilePayloadTemplate.title="New File" Mattermost Payload
+${moduleId}.content.templates.apsNewFilePayloadTemplate.title="New File" Aps Payload

--- a/repository/src/main/messages/bootstrap_de.properties
+++ b/repository/src/main/messages/bootstrap_de.properties
@@ -2,3 +2,4 @@ ${moduleId}.spaces.templates.actionTemplates.name=Vorlagen f\u00fcr Aktionen von
 ${moduleId}.spaces.templates.webhookPayloadTemplates.name=Payload-Vorlagen f\u00fcr Webhook-Aufruf
 ${moduleId}.content.templates.discordNewFilePayloadTemplate.title="Neue Datei" Discord Payload
 ${moduleId}.content.templates.mattermostNewFilePayloadTemplate.title="Neue Datei" Mattermost Payload
+${moduleId}.content.templates.apsNewFilePayloadTemplate.title="Neue Datei" APS Payload


### PR DESCRIPTION
Hi Axel. 

Thank you pretty much for this awesome action amp. Regarding to this tutorial https://hub.alfresco.com/t5/alfresco-process-services/using-rest-call-with-a-start-signal-event-in-aps/ba-p/288943 I managed to use the webhook to start an APS Flow with uploading to an ACS folder. Even better the document id is forwarded to the APS Workflow as well. Any feedback is much welcomed :).

If you allow I would like to write a blog post about my work + using your amp.